### PR TITLE
Use real start / end dates in scheduler form

### DIFF
--- a/templates/manager/scheduler/timeBlockForm.tpl
+++ b/templates/manager/scheduler/timeBlockForm.tpl
@@ -41,18 +41,18 @@
 <tr valign="top">
 	<td class="label">{fieldLabel key="common.date"}</td>
 	<td class="value">
-		{html_select_date prefix="startTime" all_extra="selectMenu" time=$startTime}
+		{html_select_date prefix="startTime" all_extra="selectMenu" time=$currentSchedConf->getSetting('startDate')}
 	</td>
 <tr valign="top">
 	<td class="label">{fieldLabel key="manager.scheduler.timeBlock.startTime"}</td>
 	<td class="value" width="30%">
-		{html_select_time prefix="startTime" use_24_hours=false minute_interval=5 display_seconds=false all_extra="class=\"selectMenu\"" time=$startTime}
+		{html_select_time prefix="startTime" use_24_hours=false minute_interval=5 display_seconds=false all_extra="class=\"selectMenu\"" time=$currentSchedConf->getSetting('startDate')}
 	</td>
 </tr>
 <tr valign="top">
 	<td class="label">{translate key="manager.scheduler.timeBlock.endTime"}</td>
 	<td class="value">
-		{html_select_time prefix="endTime" use_24_hours=false minute_interval=5 display_seconds=false all_extra="class=\"selectMenu\"" time=$endTime}
+		{html_select_time prefix="endTime" use_24_hours=false minute_interval=5 display_seconds=false all_extra="class=\"selectMenu\"" time=$currentSchedConf->getSetting('endDate')}
 	</td>
 </tr>
 </table>


### PR DESCRIPTION
If you have a conference that is next year, and try to create a time block: manager/createTimeBlock, then you'll notice that the dropdown for the time block defaults to today's date, and the year dropdown only has this year. This is an issue because the user can't select the timeblock to be next year (the year of the conference). Thus the user ends up only being able to create time blocks in 2012, as opposed to time blocks during the conference.

Digging into the code, I've noticed that the local variables `$startTime` and `$endTime` don't appear to have any data (so its falling back to todays date). To fix this (for us, and it should work generically),  I changed it to use the conference's start/end date. 

Apologies in advance if your workflow is to not use GitHub for this...
