### PR TITLE
*8861* Dates  with different format are compared

### DIFF
--- a/classes/manager/form/TimelineForm.inc.php
+++ b/classes/manager/form/TimelineForm.inc.php
@@ -151,8 +151,8 @@ class TimelineForm extends Form {
 		$schedConf =& Request::getSchedConf();
 
 		$this->_data = array(
-			'siteStartDate' => $schedConf->getStartDate(),
-			'siteEndDate' => $schedConf->getEndDate(),
+			'siteStartDate' => strtotime($schedConf->getStartDate()),
+			'siteEndDate' =>  strtotime($schedConf->getEndDate()),
 
 			'startDate' => $schedConf->getSetting('startDate'),
 			'endDate' => $schedConf->getSetting('endDate'),


### PR DESCRIPTION
siteStartDate and siteEndDate are in different formats to be compared with startDate and endDate variables.
Test Case: 
Go to the form TimeLineForm.inc.php (index.php/conf/someschedconf/manager/timeline) and setup a conference schedule to siteStart equals 2014-6-1, siteEndDate  equals 2014-9-30, startDate equals 2014-09-12 and endDate equals 2014-09-13. Save it. Check the table 'sched_confs' and verify that all is Okay for siteEndDate value. It's 2014-9-30 as expected. Now, go back to the same schedule conference form and check again their value, it's 2014-09-14! That's the bug.
