### PR TITLE
Added changes to enable easier overiding

### DIFF
--- a/classes/submission/form/MetadataForm.inc.php
+++ b/classes/submission/form/MetadataForm.inc.php
@@ -30,6 +30,8 @@ class MetadataForm extends Form {
 	 * Constructor.
 	 */
 	function MetadataForm($paper) {
+		$this->paper = $paper;
+                
 		$roleDao =& DAORegistry::getDAO('RoleDAO');
 
 		$schedConf =& Request::getSchedConf();
@@ -64,8 +66,6 @@ class MetadataForm extends Form {
 		if ($roleId != null && $roleId == ROLE_ID_REVIEWER) {
 			$this->canViewAuthors = false;
 		}
-
-		$this->paper = $paper;
 
 		$this->addCheck(new FormValidatorPost($this));
 	}
@@ -114,6 +114,8 @@ class MetadataForm extends Form {
 				}
 			}
 		}
+                
+                parent::initData();
 	}
 
 	/**


### PR DESCRIPTION
`parent::initData();` was added to the bottom of the `initData` method to ensure the `metadaform::initdata` hook is called.

`$this->paper = $paper;` was moved to the top of the MetadataFrom constructor to expose the $paper object to the `MetadataForm::Constructor` hook used in the parent Form constructor.