### PR TITLE
fixed a fatal error

### DIFF
--- a/pages/admin/AdminPeopleHandler.inc.php
+++ b/pages/admin/AdminPeopleHandler.inc.php
@@ -111,8 +111,8 @@ class AdminPeopleHandler extends AdminHandler {
 
 		if ($roleId == ROLE_ID_REVIEWER) {
 			$reviewAssignmentDao =& DAORegistry::getDAO('ReviewAssignmentDAO');
-			$templateMgr->assign('rateReviewerOnQuality', $conference->getSetting('rateReviewerOnQuality'));
-			$templateMgr->assign('qualityRatings', $conference->getSetting('rateReviewerOnQuality') ? $reviewAssignmentDao->getAverageQualityRatings($conference->getId()) : null);
+			$templateMgr->assign('rateReviewerOnQuality', $conference?$conference->getSetting('rateReviewerOnQuality'):null);
+			$templateMgr->assign('qualityRatings', $conference && $conference->getSetting('rateReviewerOnQuality') ? $reviewAssignmentDao->getAverageQualityRatings($conference->getId()) : null);
 		}
 		$templateMgr->assign('fieldOptions', Array(
 			USER_FIELD_FIRSTNAME => 'user.firstName',


### PR DESCRIPTION
Fixed the fatal error that show this message: "Call to a member function getSetting() on null in" .. "pages/admin/AdminPeopleHandler.inc.php on line 114"

This error may be generated following this path:
 Home > User > Site Administration > Merge Users > Reviewers