### PR TITLE
Fixed getDirectorsNotInTrack() to use schedConfId and not conferenceId

### DIFF
--- a/classes/manager/form/TrackForm.inc.php
+++ b/classes/manager/form/TrackForm.inc.php
@@ -114,7 +114,7 @@ class TrackForm extends Form {
 	function initData() {
 		$conference =& Request::getConference();
 		$trackDirectorsDao =& DAORegistry::getDAO('TrackDirectorsDAO');
-		$schedConf =& Request::getSchedConf(); //Necessary to fix a bug - Bruno Clemente
+		$schedConf =& Request::getSchedConf(); 
 		
 		if (isset($this->trackId)) {
 			$trackDao =& DAORegistry::getDAO('TrackDAO');
@@ -138,7 +138,7 @@ class TrackForm extends Form {
 			}
 		} else {
 			$this->_data = array(
-				'unassignedDirectors' => $trackDirectorsDao->getDirectorsNotInTrack($schedConf->getId(), null)  //Fixed a bug where all track director of this conference were shown -- Bruno Clemente
+				'unassignedDirectors' => $trackDirectorsDao->getDirectorsNotInTrack($schedConf->getId(), null) 
 			);
 
 		}

--- a/classes/manager/form/TrackForm.inc.php
+++ b/classes/manager/form/TrackForm.inc.php
@@ -114,6 +114,7 @@ class TrackForm extends Form {
 	function initData() {
 		$conference =& Request::getConference();
 		$trackDirectorsDao =& DAORegistry::getDAO('TrackDirectorsDAO');
+		$schedConf =& Request::getSchedConf(); //Necessary to fix a bug - Bruno Clemente
 		
 		if (isset($this->trackId)) {
 			$trackDao =& DAORegistry::getDAO('TrackDAO');
@@ -137,7 +138,7 @@ class TrackForm extends Form {
 			}
 		} else {
 			$this->_data = array(
-				'unassignedDirectors' => $trackDirectorsDao->getDirectorsNotInTrack($conference->getId(), null)
+				'unassignedDirectors' => $trackDirectorsDao->getDirectorsNotInTrack($schedConf->getId(), null)  //Fixed a bug where all track director of this conference were shown -- Bruno Clemente
 			);
 
 		}


### PR DESCRIPTION
All track directors from the conference were shown as possible to add as track director to a track and not just track directors from the specified sched conf