### PR TITLE
Fixed a bug where wrong schedConfs were displayed in the archive tab

### DIFF
--- a/classes/schedConf/SchedConfDAO.inc.php
+++ b/classes/schedConf/SchedConfDAO.inc.php
@@ -328,7 +328,26 @@ class SchedConfDAO extends DAO {
 		$resultFactory = new DAOResultFactory($result, $this, '_returnSchedConfFromRow');
 		return $resultFactory;
 	}
+	/*alteration done by Everton Junior
+	/**
+	 * Retrieve past enableds scheduleds conferences of a given conference
+	 * @return array SchedConfs ordered by sequence
+	 */
+	function &getPastSchedConfs($conferenceId) {
+		$result =& $this->retrieve('
+			SELECT i.* FROM sched_confs i
+				LEFT JOIN conferences c ON (i.conference_id = c.conference_id)
+			WHERE c.enabled = 1
+				AND i.conference_id = ?
+				AND i.end_date < NOW()
+			ORDER BY c.seq, i.seq',
+			$conferenceId);
 
+		$resultFactory = new DAOResultFactory($result, $this, '_returnSchedConfFromRow');
+		return $resultFactory;
+	}
+	//end alteration
+	
 	/**
 	 * Check if one or more archived scheduled conferences exist for a conference.
 	 * @param $conferenceId the conference owning the scheduled conference

--- a/pages/schedConfs/SchedConfsHandler.inc.php
+++ b/pages/schedConfs/SchedConfsHandler.inc.php
@@ -87,7 +87,7 @@ class SchedConfsHandler extends Handler {
 		$templateMgr->assign('conferenceTitle', $conference->getConferenceTitle());
 
 		$schedConfDao =& DAORegistry::getDAO('SchedConfDAO');
-		$pastSchedConfs =& $schedConfDao->getEnabledSchedConfs($conference->getId());
+		$pastSchedConfs =& $schedConfDao->getPastSchedConfs($conference->getId());
 
 		$templateMgr->assign_by_ref('schedConfs', $pastSchedConfs);
 


### PR DESCRIPTION
In the file SchedConfsHandler.in.php, was called the function getEnabledSchedConfs to get all scheConfs to display at the archive tab. Changed the function to a new one, getPastSchedConfs