### PR TITLE
Correcting a Copy-Paste English language key

### DIFF
--- a/plugins/paymethod/paypal/locale/en_US/emailTemplates.xml
+++ b/plugins/paymethod/paypal/locale/en_US/emailTemplates.xml
@@ -35,6 +35,6 @@ Server vars:
 The invoice ID for this transaction is "{$invoiceId}".
 
 {$registrationContactSignature}</body>
-		<description>This email template is used to notify a conference's primary contact that suspicious activity or activity requiring manual intervention was encountered by the PayPal plugin.</description>
+		<description>This email template is used to notify a conference's primary contact that a registration fee for a registrant has been recieved via PayPal plugin.</description>
 	</email_text>
 </email_texts>


### PR DESCRIPTION
I found this neglected language key while revising the Arabic locale files.